### PR TITLE
Adding tests, more GraphSON handling, and registration of queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Request:
 curl \
 	-H 'Content-Type: application/json' \
 	-X POST localhost:8080/edge \
-	-d '{"label":"drove", "head":{"label":"person","name":"Bonnie"},"tail":{"label":"vehicle","name":"1932 Ford V-8 B-400 convertible sedan"}}'
+	-d '{"label":"drove", "head":{"label":"person","properties" : {"name":"Bonnie"}},"tail":{"label":"vehicle", "properties":{"name":"1932 Ford V-8 B-400 convertible sedan"}}}'
 ```
 
 ### POST `/vertex`
@@ -50,7 +50,7 @@ Request:
 curl \
 	-H 'Content-Type: application/json' \
 	-X POST localhost:8080/vertex \
-	-d '{"label":"person","name":"Clyde"}'
+	-d '{"label":"person","properties":{"name":"Clyde"}}'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ curl \
 	-X GET localhost:8080/query \
 	-d '{"gremlin":"g.V().has(\"name\", \"Bonnie\")"}'
 ```
+
+## Code
+If you are interested in contributing and jumping into the code, start with [GZeroService.scala](https://github.com/jamesjgardner/gzero/blob/master/src/main/scala/one/gzero/api/GZeroService.scala)
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gzero
-GZero simplifies large scale graph-based computing, storage, and machine learning model predictions.
+GZero simplifies large scale graph-based computing, storage, and machine learning model predictions. All features and labels will be expressed as graph traversals. A user may specify the features necessary to construct a feature vector with the appropriate labels and the framework will provide an easy API for training, evaluating, and performing predictions with stored models.
 
 ## Getting Started
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,14 @@
 organization := "one.gzero"
 
+name := "gzero"
+
 version := "0.0.1-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
+
+publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
 
 val akkaV = "2.3.9"
 val sprayV = "1.3.3"
@@ -38,9 +42,9 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies += "org.scalactic" %% "scalactic" % "2.2.6"
+
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 
 resolvers += "Local Maven" at Path.userHome.asFile.toURI.toURL + ".m2/repository"
-
 
 Revolver.settings

--- a/build.sbt
+++ b/build.sbt
@@ -33,9 +33,12 @@ libraryDependencies ++= Seq(
   //    "com.thinkaurelius.titan" % "titan-hbase" % titanV,
   //    "com.thinkaurelius.titan" % "titan-solr" % titanV,
   "org.apache.tinkerpop" % "tinkergraph-gremlin" % gremlinV,
-  "org.apache.tinkerpop" % "gremlin-driver" % gremlinV,
-  "org.specs2" %% "specs2-core" % "2.3.11" % "test"
+  "org.apache.tinkerpop" % "gremlin-driver" % gremlinV
+  //"org.specs2" %% "specs2-core" % "2.3.11" % "test"
 )
+
+libraryDependencies += "org.scalactic" %% "scalactic" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 
 resolvers += "Local Maven" at Path.userHome.asFile.toURI.toURL + ".m2/repository"
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+gzero {
+  interface = "localhost"
+  port = 8383
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -2,3 +2,15 @@ gzero {
   interface = "localhost"
   port = 8383
 }
+
+titan {
+  gremlin-server {
+    address = "http://localhost:8182"
+  }
+  cassandra {
+    hostname = "127.0.0.1"
+  }
+  elasticsearch {
+    hostname = "127.0.0.1"
+  }
+}

--- a/src/main/scala/one/gzero/Boot.scala
+++ b/src/main/scala/one/gzero/Boot.scala
@@ -10,7 +10,8 @@ import spray.can.Http
 
 import scala.concurrent.duration._
 
-object Boot extends App {
+
+object Boot extends App with Config {
 
   // we need an ActorSystem to host our application in
   implicit val system = ActorSystem("gzero-system")
@@ -22,5 +23,5 @@ object Boot extends App {
 
   implicit val timeout = Timeout(5.seconds)
   // start a new HTTP server on port 8080 with our service actor as the handler
-  IO(Http) ? Http.Bind(service, interface = "localhost", port = 8383)
+  IO(Http) ? Http.Bind(service, interface = interface, port = port)
 }

--- a/src/main/scala/one/gzero/Boot.scala
+++ b/src/main/scala/one/gzero/Boot.scala
@@ -23,5 +23,5 @@ object Boot extends App with Config {
 
   implicit val timeout = Timeout(5.seconds)
   // start a new HTTP server on port 8080 with our service actor as the handler
-  IO(Http) ? Http.Bind(service, interface = interface, port = port)
+  IO(Http) ? Http.Bind(service, interface = gzeroInterface, port = gzeroPort)
 }

--- a/src/main/scala/one/gzero/Boot.scala
+++ b/src/main/scala/one/gzero/Boot.scala
@@ -19,8 +19,8 @@ object Boot extends App with Config {
   val service = system.actorOf(Props[GzeroServiceActor], "gzero-api")
   //val publisher = system.actorOf(Props[GraphPublisher], "gzero-graphpublisher")
 
-
-  implicit val timeout = Timeout(5.seconds)
+  //two minute timeout -- TODO - configure this in application.conf
+  implicit val timeout = Timeout(120.seconds)
   // start a new HTTP server on port 8080 with our service actor as the handler
   IO(Http) ? Http.Bind(service, interface = gzeroInterface, port = gzeroPort)
 }

--- a/src/main/scala/one/gzero/Boot.scala
+++ b/src/main/scala/one/gzero/Boot.scala
@@ -22,5 +22,5 @@ object Boot extends App {
 
   implicit val timeout = Timeout(5.seconds)
   // start a new HTTP server on port 8080 with our service actor as the handler
-  IO(Http) ? Http.Bind(service, interface = "localhost", port = 8080)
+  IO(Http) ? Http.Bind(service, interface = "localhost", port = 8383)
 }

--- a/src/main/scala/one/gzero/Boot.scala
+++ b/src/main/scala/one/gzero/Boot.scala
@@ -4,8 +4,7 @@ import akka.actor.{ActorSystem, Props}
 import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
-import one.gzero.api.GZeroServiceActor
-import one.gzero.db.GraphPublisher
+import one.gzero.api.GzeroServiceActor
 import spray.can.Http
 
 import scala.concurrent.duration._
@@ -17,7 +16,7 @@ object Boot extends App with Config {
   implicit val system = ActorSystem("gzero-system")
 
   // create and start our actors
-  val service = system.actorOf(Props[GZeroServiceActor], "gzero-api")
+  val service = system.actorOf(Props[GzeroServiceActor], "gzero-api")
   //val publisher = system.actorOf(Props[GraphPublisher], "gzero-graphpublisher")
 
 

--- a/src/main/scala/one/gzero/Config.scala
+++ b/src/main/scala/one/gzero/Config.scala
@@ -5,8 +5,17 @@ import com.typesafe.config.ConfigFactory
 trait Config {
   private val config = ConfigFactory.load()
   private val gzeroConfig = config.getConfig("gzero")
+  private val titanConfig = config.getConfig("titan")
+  private val gremlinServerConfig = titanConfig.getConfig("gremlin-server")
+  private val cassandraConfig = titanConfig.getConfig("cassandra")
+  private val elasticSearchConfig = titanConfig.getConfig("elasticsearch")
 
-  val interface = gzeroConfig.getString("interface")
-  val port = gzeroConfig.getInt("port")
+  val gzeroInterface = gzeroConfig.getString("interface")
+  val gzeroPort = gzeroConfig.getInt("port")
+
+  val cassandraHostName = cassandraConfig.getString("hostname")
+  val elasticsearchHostName = elasticSearchConfig.getString("hostname")
+
+  val gremlinServerAddress = gremlinServerConfig.getString("address") //fully qualified rest style
 }
 

--- a/src/main/scala/one/gzero/Config.scala
+++ b/src/main/scala/one/gzero/Config.scala
@@ -1,0 +1,12 @@
+package one.gzero
+
+import com.typesafe.config.ConfigFactory
+
+trait Config {
+  private val config = ConfigFactory.load()
+  private val gzeroConfig = config.getConfig("gzero")
+
+  val interface = gzeroConfig.getString("interface")
+  val port = gzeroConfig.getInt("port")
+}
+

--- a/src/main/scala/one/gzero/api/Events.scala
+++ b/src/main/scala/one/gzero/api/Events.scala
@@ -1,10 +1,26 @@
 package one.gzero.api
 
-import spray.json.JsObject
+import spray.json._
 
 /*case classes used by spray for marshalling and unmarshalling of JSON*/
-case class Vertex(label:String, name:String, event_source: Option[String], timestamp: Option[String], properties: Option[JsObject])
+//case class VertexProperties(name:String, event_source: Option[String], timestamp: Option[String])
+case class Vertex(label:String, properties : Option[JsObject]) {
+  def getProperty(key : String) : String = {
+    properties.get.fields.get(key).get.convertTo[String]
+  }
+}
 case class Edge(label: String, name:Option[String], event_source: Option[String], timestamp: Option[String], properties: Option[JsObject],
                 head: Vertex, tail: Vertex)
 /*used for querying the graph*/
-case class Query(gremlin: String)
+case class Query(gremlin: String, bindings:Option[JsObject], tags:Option[JsArray])
+case class BindingsPropert(bindings:String)
+
+case class GraphSONEdge(outV:Int, inV:Int, label:String, properties: Option[JsObject])
+case class GraphSONVertex(label:String, id:Option[Int], properties: Option[JsObject])
+
+/* TODO - consider dropping Protocols and put implicit JSON conversion directly in the Vertex,Edge, Query classes */
+trait GzeroProtocols extends DefaultJsonProtocol {
+  implicit val impVertex = jsonFormat2(Vertex.apply)
+  implicit val impEdge = jsonFormat7(Edge.apply)
+  implicit val impQuery = jsonFormat3(Query.apply)
+}

--- a/src/main/scala/one/gzero/api/Events.scala
+++ b/src/main/scala/one/gzero/api/Events.scala
@@ -1,9 +1,9 @@
 package one.gzero.api
 
 import spray.json._
-import DefaultJsonProtocol._
 
 abstract class PropertyHolder {
+  import DefaultJsonProtocol._
   val properties : Option[JsObject]
   def getProperty(key : String) : String = {
     properties.get.fields.get(key).get.convertTo[String]

--- a/src/main/scala/one/gzero/api/Events.scala
+++ b/src/main/scala/one/gzero/api/Events.scala
@@ -30,6 +30,8 @@ case class Edge(label: String, name:Option[String], event_source: Option[String]
 /*used for querying the graph*/
 case class Query(gremlin: String, bindings:Option[JsObject], tags:Option[JsArray])
 
+case class FeatureQuery(name: String, bindings:Option[JsObject])
+
 case class GraphSONEdge(outV:Int, inV:Int, label:String, properties: Option[JsObject])
 case class GraphSONVertex(label:String, id:Option[Int], properties: Option[JsObject])
 
@@ -38,4 +40,5 @@ trait GzeroProtocols extends DefaultJsonProtocol {
   implicit val impVertex = jsonFormat2(Vertex.apply)
   implicit val impEdge = jsonFormat7(Edge.apply)
   implicit val impQuery = jsonFormat3(Query.apply)
+  implicit val impFeatureQuery = jsonFormat2(FeatureQuery.apply)
 }

--- a/src/main/scala/one/gzero/api/Events.scala
+++ b/src/main/scala/one/gzero/api/Events.scala
@@ -30,7 +30,7 @@ case class Edge(label: String, name:Option[String], event_source: Option[String]
 /*used for querying the graph*/
 case class Query(gremlin: String, bindings:Option[JsObject], tags:Option[JsArray])
 
-case class FeatureQuery(name: String, bindings:Option[JsObject])
+case class FeatureQuery(name: String, id : Option[Int], bindings:Option[JsObject])
 
 case class GraphSONEdge(outV:Int, inV:Int, label:String, properties: Option[JsObject])
 case class GraphSONVertex(label:String, id:Option[Int], properties: Option[JsObject])
@@ -40,5 +40,5 @@ trait GzeroProtocols extends DefaultJsonProtocol {
   implicit val impVertex = jsonFormat2(Vertex.apply)
   implicit val impEdge = jsonFormat7(Edge.apply)
   implicit val impQuery = jsonFormat3(Query.apply)
-  implicit val impFeatureQuery = jsonFormat2(FeatureQuery.apply)
+  implicit val impFeatureQuery = jsonFormat3(FeatureQuery.apply)
 }

--- a/src/main/scala/one/gzero/api/Events.scala
+++ b/src/main/scala/one/gzero/api/Events.scala
@@ -1,6 +1,8 @@
 package one.gzero.api
 
 import spray.json._
+import DefaultJsonProtocol._
+
 
 /*case classes used by spray for marshalling and unmarshalling of JSON*/
 //case class VertexProperties(name:String, event_source: Option[String], timestamp: Option[String])
@@ -8,12 +10,16 @@ case class Vertex(label:String, properties : Option[JsObject]) {
   def getProperty(key : String) : String = {
     properties.get.fields.get(key).get.convertTo[String]
   }
+  def name : String = getProperty("name")
 }
 case class Edge(label: String, name:Option[String], event_source: Option[String], timestamp: Option[String], properties: Option[JsObject],
-                head: Vertex, tail: Vertex)
+                head: Vertex, tail: Vertex) {
+  def getProperty(key : String) : String = {
+    properties.get.fields.get(key).get.convertTo[String]
+  }
+}
 /*used for querying the graph*/
 case class Query(gremlin: String, bindings:Option[JsObject], tags:Option[JsArray])
-case class BindingsPropert(bindings:String)
 
 case class GraphSONEdge(outV:Int, inV:Int, label:String, properties: Option[JsObject])
 case class GraphSONVertex(label:String, id:Option[Int], properties: Option[JsObject])

--- a/src/main/scala/one/gzero/api/Events.scala
+++ b/src/main/scala/one/gzero/api/Events.scala
@@ -8,8 +8,14 @@ abstract class PropertyHolder {
   def getProperty(key : String) : String = {
     properties.get.fields.get(key).get.convertTo[String]
   }
+  def getListProperty(key : String) : List[String] = {
+    properties.get.fields.get(key).get.convertTo[List[String]]
+  }
   def getDoubleProperty(key : String) : Double = {
     properties.get.fields.get(key).get.convertTo[Double]
+  }
+  def getIntProperty(key : String) : Int = {
+    properties.get.fields.get(key).get.convertTo[Int]
   }
 }
 

--- a/src/main/scala/one/gzero/api/Events.scala
+++ b/src/main/scala/one/gzero/api/Events.scala
@@ -3,21 +3,24 @@ package one.gzero.api
 import spray.json._
 import DefaultJsonProtocol._
 
+abstract class PropertyHolder {
+  val properties : Option[JsObject]
+  def getProperty(key : String) : String = {
+    properties.get.fields.get(key).get.convertTo[String]
+  }
+  def getDoubleProperty(key : String) : Double = {
+    properties.get.fields.get(key).get.convertTo[Double]
+  }
+}
+
 
 /*case classes used by spray for marshalling and unmarshalling of JSON*/
 //case class VertexProperties(name:String, event_source: Option[String], timestamp: Option[String])
-case class Vertex(label:String, properties : Option[JsObject]) {
-  def getProperty(key : String) : String = {
-    properties.get.fields.get(key).get.convertTo[String]
-  }
+case class Vertex(label:String, properties : Option[JsObject]) extends PropertyHolder {
   def name : String = getProperty("name")
 }
 case class Edge(label: String, name:Option[String], event_source: Option[String], timestamp: Option[String], properties: Option[JsObject],
-                head: Vertex, tail: Vertex) {
-  def getProperty(key : String) : String = {
-    properties.get.fields.get(key).get.convertTo[String]
-  }
-}
+                head: Vertex, tail: Vertex) extends PropertyHolder
 /*used for querying the graph*/
 case class Query(gremlin: String, bindings:Option[JsObject], tags:Option[JsArray])
 

--- a/src/main/scala/one/gzero/api/Events.scala
+++ b/src/main/scala/one/gzero/api/Events.scala
@@ -34,6 +34,8 @@ case class FeatureQuery(name: String, id : Option[Int], bindings:Option[JsObject
 
 case class GraphSONEdge(outV:Int, inV:Int, label:String, properties: Option[JsObject])
 case class GraphSONVertex(label:String, id:Option[Int], properties: Option[JsObject])
+case class GzeroResult(result: JsObject, status: JsObject)
+
 
 /* TODO - consider dropping Protocols and put implicit JSON conversion directly in the Vertex,Edge, Query classes */
 trait GzeroProtocols extends DefaultJsonProtocol {
@@ -41,4 +43,5 @@ trait GzeroProtocols extends DefaultJsonProtocol {
   implicit val impEdge = jsonFormat7(Edge.apply)
   implicit val impQuery = jsonFormat3(Query.apply)
   implicit val impFeatureQuery = jsonFormat3(FeatureQuery.apply)
+  implicit val gzProt = jsonFormat2(GzeroResult)
 }

--- a/src/main/scala/one/gzero/api/GZeroService.scala
+++ b/src/main/scala/one/gzero/api/GZeroService.scala
@@ -56,6 +56,7 @@ trait GzeroService extends HttpService with CassandraElasticSearchConnect with V
     if (edge.properties.isDefined) {
       //TODO - update the properties of the edge
       for( (k,v) <- edge.properties.get.fields  ) {
+        println("updating edge:", k,v)
         //attempt to convert to int. if fail just convert to string
         //TODO this is probably really slow
         val x = try {
@@ -72,7 +73,6 @@ trait GzeroService extends HttpService with CassandraElasticSearchConnect with V
           }
         }
         e.setProperty(TitanUtils.convertToTitanKey(k), x)
-        println(k,v, x)
       }
     }
     g.tx().commit()

--- a/src/main/scala/one/gzero/api/GZeroService.scala
+++ b/src/main/scala/one/gzero/api/GZeroService.scala
@@ -10,7 +10,7 @@ import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
 import com.thinkaurelius.titan.core.TitanGraph
 import one.gzero.api.{Edge => GEdge, Vertex => GVertex}
 import gremlin.scala._
-
+import spray.json._
 import scala.collection.mutable
 
 
@@ -64,9 +64,9 @@ trait GzeroService extends HttpService with GzeroProtocols with CassandraElastic
   }
 
   def handleRegisterFeature(req: Query): String = {
-    val (g, b, t) = (req.gremlin, req.bindings, req.tags)
+    val (gremlin, b, t) = (req.gremlin, req.bindings, req.tags)
 
-    val gv = new GVertex("feature", Some(JsObject("name" -> JsString(g))))
+    val gv = new GVertex("feature", Some(JsObject("name" -> JsString(gremlin))))
     val v = getOrCreateVertex(gv)
 
     // The general technique will be to define the query logic with all optional parameters as
@@ -84,7 +84,6 @@ trait GzeroService extends HttpService with GzeroProtocols with CassandraElastic
 
   /* {"name":"feature_name", "bindings" : {}} */
   def handleFeature(req: FeatureQuery): String = {
-    import spray.json._
     val gremlin = req.name
     val vo = g.V.hasLabel("feature").has(NameKey, req.name).headOption()
     val res = if (vo.isDefined) {

--- a/src/main/scala/one/gzero/api/GZeroService.scala
+++ b/src/main/scala/one/gzero/api/GZeroService.scala
@@ -103,7 +103,7 @@ trait GZeroService extends HttpService with GzeroProtocols with LocalCassandraCo
           (get & entity(as[Query])) {
             queryRequest => {
               complete {
-                query(queryRequest.gremlin)
+                query(queryRequest)
               }
             }
           }
@@ -116,6 +116,15 @@ trait GZeroService extends HttpService with GzeroProtocols with LocalCassandraCo
               }
             }
         }
-      }
+      } ~
+        path("feature") {
+          (post & entity(as[Query])) {
+            req => {
+              complete {
+                handleRegisterFeature(req)
+              }
+            }
+          }
+        }
   }
 }

--- a/src/main/scala/one/gzero/api/GZeroService.scala
+++ b/src/main/scala/one/gzero/api/GZeroService.scala
@@ -4,9 +4,8 @@ import java.sql.Timestamp
 
 import akka.actor.Actor
 import one.gzero.db.{LocalGremlinQuery, LocalCassandraConnect, VertexCache}
-import org.apache.tinkerpop.gremlin.driver.{Client, Cluster}
 import spray.routing._
-import spray.json.{JsArray, JsString, JsObject, DefaultJsonProtocol}
+import spray.json.{JsString, JsObject}
 import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
 import com.thinkaurelius.titan.core.TitanGraph
 import one.gzero.api.{Edge => GEdge, Vertex => GVertex}

--- a/src/main/scala/one/gzero/api/GZeroService.scala
+++ b/src/main/scala/one/gzero/api/GZeroService.scala
@@ -61,8 +61,8 @@ trait GZeroService extends HttpService with GzeroProtocols with LocalCassandraCo
   }
 
   def handleRegisterFeature(req:Query): String = {
-    val BindingsKey = Key[JsObject]("bindings")
-    val TagsKey = Key[JsArray]("tags")
+    val BindingsKey = Key[String]("bindings")
+    val TagsKey = Key[String]("tags")
 
     val (g,b,t) = (req.gremlin, req.bindings, req.tags)
 
@@ -73,11 +73,12 @@ trait GZeroService extends HttpService with GzeroProtocols with LocalCassandraCo
     // bindings. When "executing the feature" you can pass the bindings without the gremlin query
     // and the stored query will be executed with the bindings updated.
     if ( b.isDefined ) {
-      v.setProperty(BindingsKey, b.get)
+      v.setProperty(BindingsKey, b.get.toString)
     }
     if ( t.isDefined ) {
-      v.setProperty(TagsKey, t.get)
+      v.setProperty(TagsKey, t.get.toString)
     }
+    v.graph().tx().commit()
     s"""{"register_ack" : $v}"""
   }
 

--- a/src/main/scala/one/gzero/api/GZeroService.scala
+++ b/src/main/scala/one/gzero/api/GZeroService.scala
@@ -3,7 +3,7 @@ package one.gzero.api
 import java.sql.Timestamp
 
 import akka.actor.Actor
-import one.gzero.db.{LocalGremlinQuery, LocalCassandraConnect, VertexCache}
+import one.gzero.db.{LocalGremlinQuery, CassandraElasticSearchConnect, VertexCache}
 import spray.routing._
 import spray.json.{JsString, JsObject}
 import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
@@ -20,7 +20,7 @@ class GZeroServiceActor extends Actor with GZeroService {
   def receive = runRoute(routes)
 }
 
-trait GZeroService extends HttpService with GzeroProtocols with LocalCassandraConnect with VertexCache with LocalGremlinQuery {
+trait GZeroService extends HttpService with GzeroProtocols with CassandraElasticSearchConnect with VertexCache with LocalGremlinQuery {
   var graphJava: TitanGraph = null
   lazy val g = graphJava.asScala
 

--- a/src/main/scala/one/gzero/api/GZeroService.scala
+++ b/src/main/scala/one/gzero/api/GZeroService.scala
@@ -3,7 +3,7 @@ package one.gzero.api
 import java.sql.Timestamp
 
 import akka.actor.Actor
-import one.gzero.db.{LocalGremlinQuery, CassandraElasticSearchConnect, VertexCache}
+import one.gzero.db.{GremlinServerConnect, CassandraElasticSearchConnect, VertexCache}
 import spray.routing._
 import spray.json.{JsString, JsObject}
 import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
@@ -20,7 +20,7 @@ class GZeroServiceActor extends Actor with GZeroService {
   def receive = runRoute(routes)
 }
 
-trait GZeroService extends HttpService with GzeroProtocols with CassandraElasticSearchConnect with VertexCache with LocalGremlinQuery {
+trait GZeroService extends HttpService with GzeroProtocols with CassandraElasticSearchConnect with VertexCache with GremlinServerConnect {
   var graphJava: TitanGraph = null
   lazy val g = graphJava.asScala
 

--- a/src/main/scala/one/gzero/api/GZeroService.scala
+++ b/src/main/scala/one/gzero/api/GZeroService.scala
@@ -6,7 +6,7 @@ import akka.actor.Actor
 import one.gzero.db.{LocalGremlinQuery, LocalCassandraConnect, VertexCache}
 import org.apache.tinkerpop.gremlin.driver.{Client, Cluster}
 import spray.routing._
-import spray.json.{JsString, JsObject, DefaultJsonProtocol}
+import spray.json.{JsArray, JsString, JsObject, DefaultJsonProtocol}
 import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
 import com.thinkaurelius.titan.core.TitanGraph
 import one.gzero.api.{Edge => GEdge, Vertex => GVertex}
@@ -82,6 +82,9 @@ trait GZeroService extends HttpService with GzeroProtocols with LocalCassandraCo
           (post & entity(as[Query])) {
             req => {
               complete {
+                val BindingsKey = Key[JsObject]("bindings")
+                val TagsKey = Key[JsArray]("tags")
+
                 val g = req.gremlin
                 val b = req.bindings
                 val t = req.tags
@@ -93,12 +96,10 @@ trait GZeroService extends HttpService with GzeroProtocols with LocalCassandraCo
                 // bindings. When "executing the feature" you can pass the bindings without the gremlin query
                 // and the stored query will be executed with the bindings updated.
                 if ( b.isDefined ) {
-                  val BindingsKey = Key[String]("bindings")
-                  v.setProperty(BindingsKey, b)
+                  v.setProperty(BindingsKey, b.get)
                 }
                 if ( t.isDefined ) {
-                  val TagsKey = Key[String]("tags")
-                  v.setProperty(TagsKey, b)
+                  v.setProperty(TagsKey, t.get)
                 }
 
                 s"""{"register_ack" : $v}"""

--- a/src/main/scala/one/gzero/api/GzeroConnection.scala
+++ b/src/main/scala/one/gzero/api/GzeroConnection.scala
@@ -25,9 +25,12 @@ class GzeroConnection(hostname: String, port: Int) {
     send(edge.toJson.asJsObject, "edge")
   }
 
+  def query(gremlin: Query): GzeroResult = {
+    send(gremlin.toJson.asJsObject, "query")
+  }
+
   def send(data: JsObject, path:String): GzeroResult = {
     val gzeroAddress = s"http://$hostname:$port/$path"
-
     val res =
       try {
         val responseFuture = pipeline {

--- a/src/main/scala/one/gzero/api/GzeroConnection.scala
+++ b/src/main/scala/one/gzero/api/GzeroConnection.scala
@@ -1,0 +1,57 @@
+package one.gzero.api
+
+import akka.actor.ActorSystem
+import spray.can.Http.ConnectionAttemptFailedException
+import spray.client.pipelining._
+import spray.httpx.SprayJsonSupport
+import spray.json._
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import SprayJsonSupport._
+
+/**
+  * Created by james on 3/7/16.
+  */
+
+case class GzeroResult(requestId: String, result: JsObject, status: JsObject)
+
+object Protocols extends GzeroProtocols {
+  implicit val gzProt = jsonFormat3(GzeroResult)
+}
+
+class GzeroConnection(hostname: String, port: Int) {
+  def send(data: String): GzeroResult = {
+    import Protocols._
+    val gzeroAddress = s"$hostname:$port"
+
+    implicit val system = ActorSystem("gzero-api")
+    import system.dispatcher
+
+    val pipeline = sendReceive ~> unmarshal[GzeroResult]
+
+    val res =
+      try {
+        val responseFuture = pipeline {
+          Post(gzeroAddress, data)
+        }
+        Await.result(responseFuture, 24 hours)
+        responseFuture.value.get.get
+      }
+      catch {
+        case ca: ConnectionAttemptFailedException => {
+          ca.printStackTrace()
+          GzeroResult("", JsObject("message" -> "connection failed".toJson), JsObject("error" -> "true".toJson))
+        }
+        case te: TimeoutException => {
+          te.printStackTrace()
+          GzeroResult("", JsObject("message" -> s"timeout sending data $data".toJson), JsObject("error" -> "true".toJson))
+        }
+        case e: Exception => {
+          e.printStackTrace()
+          GzeroResult("", JsObject("message" -> s"an unknown error occurred $data".toJson), JsObject("error" -> "true".toJson))
+        }
+      }
+    res
+  }
+}

--- a/src/main/scala/one/gzero/api/GzeroConnection.scala
+++ b/src/main/scala/one/gzero/api/GzeroConnection.scala
@@ -23,7 +23,7 @@ object Protocols extends GzeroProtocols {
 class GzeroConnection(hostname: String, port: Int) {
   def send(data: String): GzeroResult = {
     import Protocols._
-    val gzeroAddress = s"$hostname:$port"
+    val gzeroAddress = s"http://$hostname:$port"
 
     implicit val system = ActorSystem("gzero-api")
     import system.dispatcher

--- a/src/main/scala/one/gzero/db/GraphPublisher.scala
+++ b/src/main/scala/one/gzero/db/GraphPublisher.scala
@@ -6,7 +6,7 @@ import com.thinkaurelius.titan.core.TitanGraph
 import one.gzero.api.{Edge => GEdge, Vertex => GVertex}
 import gremlin.scala._
 
-class GraphPublisher() extends Actor with ActorLogging with CassandraElasticSearchConnect with VertexCache {
+class GraphPublisher extends Actor with ActorLogging with CassandraElasticSearchConnect with VertexCache {
   val graphJava = connect()
   val graph = graphJava
   val g = graphJava.asScala

--- a/src/main/scala/one/gzero/db/GraphPublisher.scala
+++ b/src/main/scala/one/gzero/db/GraphPublisher.scala
@@ -6,7 +6,7 @@ import com.thinkaurelius.titan.core.TitanGraph
 import one.gzero.api.{Edge => GEdge, Vertex => GVertex}
 import gremlin.scala._
 
-class GraphPublisher() extends Actor with ActorLogging with LocalCassandraConnect with VertexCache {
+class GraphPublisher() extends Actor with ActorLogging with CassandraElasticSearchConnect with VertexCache {
   val graphJava = connect()
   val graph = graphJava
   val g = graphJava.asScala

--- a/src/main/scala/one/gzero/db/Utils.scala
+++ b/src/main/scala/one/gzero/db/Utils.scala
@@ -1,13 +1,12 @@
 package one.gzero.db
 
-import java.net.URLEncoder
-
 import com.thinkaurelius.titan.core.TitanGraph
 import java.sql.Timestamp
-import one.gzero.api.{Edge => GEdge, Vertex => GVertex, GzeroProtocols, Query}
+import one.gzero.Config
+import one.gzero.api.{Vertex => GVertex, GzeroProtocols, Query}
 import gremlin.scala._
 import spray.can.Http.ConnectionAttemptFailedException
-import spray.json.{JsObject}
+import spray.json.JsObject
 import scala.concurrent.{TimeoutException, Await}
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
@@ -15,25 +14,22 @@ import spray.json._
 import spray.httpx.SprayJsonSupport
 import spray.client.pipelining._
 import SprayJsonSupport._
-import DefaultJsonProtocol._
+import com.thinkaurelius.titan.core.TitanFactory
 
 /* Inhererting this trait allows an app to simply create a titan graph object as graph = connect() */
-trait LocalCassandraConnect {
+trait LocalCassandraConnect extends Config {
   def connect(): TitanGraph = {
     import org.apache.commons.configuration.BaseConfiguration
     val conf = new BaseConfiguration()
 
     // graph storage
     conf.setProperty("storage.backend", "cassandra")
-    conf.setProperty("storage.hostname", "127.0.0.1")
+    conf.setProperty("storage.hostname", cassandraHostName)
 
     // indexing
     conf.setProperty("index.search.backend", "elasticsearch")
-    conf.setProperty("index.search.hostname" , "127.0.0.1")
+    conf.setProperty("index.search.hostname" , elasticsearchHostName)
     conf.setProperty("index.search.elasticsearch.client-only" ,  "true")
-//    conf.setProperty("index.search.elasticsearch.interface", "NODE")
-
-    import com.thinkaurelius.titan.core.TitanFactory
     TitanFactory.open(conf)
   }
 }

--- a/src/main/scala/one/gzero/db/Utils.scala
+++ b/src/main/scala/one/gzero/db/Utils.scala
@@ -12,10 +12,10 @@ import scala.concurrent.{TimeoutException, Await}
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import spray.json._
-import DefaultJsonProtocol._
 import spray.httpx.SprayJsonSupport
 import spray.client.pipelining._
 import SprayJsonSupport._
+import DefaultJsonProtocol._
 
 /* Inhererting this trait allows an app to simply create a titan graph object as graph = connect() */
 trait LocalCassandraConnect {

--- a/src/main/scala/one/gzero/db/Utils.scala
+++ b/src/main/scala/one/gzero/db/Utils.scala
@@ -17,7 +17,7 @@ import SprayJsonSupport._
 import com.thinkaurelius.titan.core.TitanFactory
 
 /* Inhererting this trait allows an app to simply create a titan graph object as graph = connect() */
-trait LocalCassandraConnect extends Config {
+trait CassandraElasticSearchConnect extends Config {
   def connect(): TitanGraph = {
     import org.apache.commons.configuration.BaseConfiguration
     val conf = new BaseConfiguration()

--- a/src/main/scala/one/gzero/db/Utils.scala
+++ b/src/main/scala/one/gzero/db/Utils.scala
@@ -16,7 +16,6 @@ import DefaultJsonProtocol._
 import spray.httpx.SprayJsonSupport
 import spray.client.pipelining._
 import SprayJsonSupport._
-import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONReader
 
 /* Inhererting this trait allows an app to simply create a titan graph object as graph = connect() */
 trait LocalCassandraConnect {

--- a/src/main/scala/one/gzero/db/Utils.scala
+++ b/src/main/scala/one/gzero/db/Utils.scala
@@ -43,6 +43,8 @@ trait VertexCache {
     val PrettyNameKey = Key[String]("prettyName")
     val RatingKey = Key[Double]("rating")
     val vertexIdCache = collection.mutable.Map[(String, String), Long]()
+    val BindingsKey = Key[String]("bindings")
+    val TagsKey = Key[String]("tags")
 
     def getOrCreateVertex(vertex: GVertex): Vertex = {
         val label = vertex.label

--- a/src/main/scala/one/gzero/db/Utils.scala
+++ b/src/main/scala/one/gzero/db/Utils.scala
@@ -84,6 +84,7 @@ trait VertexCache {
     }
     if (vertex.properties.isDefined) {
       for ((k, v) <- vertex.properties.get.fields) {
+        println("updating vertex:", k, v)
         //attempt to convert to int. if fail just convert to string
         //TODO this is probably really slow
         val x = try {

--- a/src/main/scala/one/gzero/db/Utils.scala
+++ b/src/main/scala/one/gzero/db/Utils.scala
@@ -95,7 +95,7 @@ object GremlinResultJsonProtocol extends DefaultJsonProtocol with GzeroProtocols
   implicit val gvertex = jsonFormat3(GraphSONVertex)
 }
 
-trait LocalGremlinQuery {
+trait GremlinServerConnect extends Config {
   def query(query : Query): String = {
     import GremlinResultJsonProtocol._
     val (gremlin, bindings) = (query.gremlin, query.bindings)
@@ -110,9 +110,9 @@ trait LocalGremlinQuery {
     try {
       val responseFuture = pipeline {
         if (bindings.isDefined) {
-          Post("http://localhost:8182", JsObject("gremlin" -> JsString(gremlin), "bindings" -> bindings.get))
+          Post(gremlinServerAddress, JsObject("gremlin" -> JsString(gremlin), "bindings" -> bindings.get))
         } else {
-          Post("http://localhost:8182", JsObject("gremlin" -> JsString(gremlin)))
+          Post(gremlinServerAddress, JsObject("gremlin" -> JsString(gremlin)))
         }
       }
 

--- a/src/test/scala/GremlinTests.scala
+++ b/src/test/scala/GremlinTests.scala
@@ -1,42 +1,32 @@
-import one.gzero.db.GremlinResultJsonProtocol._
 import one.gzero.db.{GraphSONEdge, GremlinResultJsonProtocol, GraphSONVertex}
-import org.specs2._
+import org.scalatest._
+
 import spray.json._
 import spray.httpx.SprayJsonSupport
 import SprayJsonSupport._
 
 
-class GremlinTests extends Specification {
+class GremlinTests extends FlatSpec with Matchers {
 
   case class NameProperty(name:String)
-
-  implicit val gresult = jsonFormat1(NameProperty)
-
   import GremlinResultJsonProtocol._
 
-  def is =
-  "GraphSON objects and strings should"                                                            ^
-    p^
-    "be convertable to GraphSONEdge"          ! e1^
-    "be convertable to GraphSONVertex with correct name property"        ! e2^
-    end
-
-  def e1 = {
+  "A GraphSON object" should "be convertible to a GraphSONEdge with correct label" in {
     val edgeJson = JsObject("inVLabel"->JsString("vehicle"),"outV"->JsNumber(8256),"label"->JsString("drove"),"outVLabel"->JsString("person"),"id"->JsString("2rs-6dc-4r9-6hs"),"type"->JsString("edge"),"inV"->JsNumber(8416))
     val edge = edgeJson.convertTo[GraphSONEdge]
-    edge.inV mustEqual 8416
-    edge.outV mustEqual 8256
-    edge.label mustEqual "drove"
+    edge.inV should be (8416)
+    edge.outV should be (8256)
+    edge.label should be ("drove")
   }
 
-  def e2 = {
+  it should "be convertible to a GraphSONVertex with corret name property " in {
+    implicit val gresult = jsonFormat1(NameProperty)
     val vJ = JsObject("label"->JsString("vehicle"),"id"->JsNumber(2),"type"->JsString("vertex"), "properties" -> JsObject("name"->JsString("1932 Ford V-8 B-400 convertible sedan")))
     val v = vJ.convertTo[GraphSONVertex]
-    v.label mustEqual "vehicle"
-    v.id mustEqual 2
+    v.label should be ("vehicle")
+    v.id.get should be (2)
     val name = v.properties.get.convertTo[NameProperty]
-    name.name mustEqual "1932 Ford V-8 B-400 convertible sedan"
+    name.name should be ("1932 Ford V-8 B-400 convertible sedan")
   }
-
 }
 

--- a/src/test/scala/GremlinTests.scala
+++ b/src/test/scala/GremlinTests.scala
@@ -19,7 +19,7 @@ class GremlinTests extends FlatSpec with Matchers {
     edge.label should be ("drove")
   }
 
-  it should "be convertible to a GraphSONVertex with corret name property " in {
+  it should "be convertible to a GraphSONVertex with correct name property " in {
     implicit val gresult = jsonFormat1(NameProperty)
     val vJ = JsObject("label"->JsString("vehicle"),"id"->JsNumber(2),"type"->JsString("vertex"), "properties" -> JsObject("name"->JsString("1932 Ford V-8 B-400 convertible sedan")))
     val v = vJ.convertTo[GraphSONVertex]

--- a/src/test/scala/GremlinTests.scala
+++ b/src/test/scala/GremlinTests.scala
@@ -1,0 +1,42 @@
+import one.gzero.db.GremlinResultJsonProtocol._
+import one.gzero.db.{GraphSONEdge, GremlinResultJsonProtocol, GraphSONVertex}
+import org.specs2._
+import spray.json._
+import spray.httpx.SprayJsonSupport
+import SprayJsonSupport._
+
+
+class GremlinTests extends Specification {
+
+  case class NameProperty(name:String)
+
+  implicit val gresult = jsonFormat1(NameProperty)
+
+  import GremlinResultJsonProtocol._
+
+  def is =
+  "GraphSON objects and strings should"                                                            ^
+    p^
+    "be convertable to GraphSONEdge"          ! e1^
+    "be convertable to GraphSONVertex with correct name property"        ! e2^
+    end
+
+  def e1 = {
+    val edgeJson = JsObject("inVLabel"->JsString("vehicle"),"outV"->JsNumber(8256),"label"->JsString("drove"),"outVLabel"->JsString("person"),"id"->JsString("2rs-6dc-4r9-6hs"),"type"->JsString("edge"),"inV"->JsNumber(8416))
+    val edge = edgeJson.convertTo[GraphSONEdge]
+    edge.inV mustEqual 8416
+    edge.outV mustEqual 8256
+    edge.label mustEqual "drove"
+  }
+
+  def e2 = {
+    val vJ = JsObject("label"->JsString("vehicle"),"id"->JsNumber(2),"type"->JsString("vertex"), "properties" -> JsObject("name"->JsString("1932 Ford V-8 B-400 convertible sedan")))
+    val v = vJ.convertTo[GraphSONVertex]
+    v.label mustEqual "vehicle"
+    v.id mustEqual 2
+    val name = v.properties.get.convertTo[NameProperty]
+    name.name mustEqual "1932 Ford V-8 B-400 convertible sedan"
+  }
+
+}
+


### PR DESCRIPTION
Decided on switching all testing to ScalaTest.
Made some of the add edge and vertex api closer to GraphSON.
Added ability to store JsObjects as vertex or edge properties.
Cleaned up some build stuff.
Gremlin server is now accessed using POST rather than GET.
